### PR TITLE
Allow some routes to not be preloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ To prevent the route from being preloaded, the return value of the
 callback must explicitly return `false`. Optionally, a `Promise` may
 be returned that can ultimately be resolved to a boolean.
 
-Any errors or rejections encountered during the callback will be
-intentionally silenced as preloading is meant to be a passive
-feature.
+Any errors or rejections encountered during the callback are intentionally
+caught as preloading is meant to be a passive and non-blocking feature.
+These errors will only be logged to the console if the
+[Vue.config.silent](https://vuejs.org/v2/api/#silent) option is disabled.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When a page is preloaded, a `preload` event is fired:
 ## Source vs. Dist
 
 By default, the `main` entry points to the compiled and minified version
-of the Vue template. This is typically fine. However, in certain cases,
+of the Vue component. This is typically fine. However, in certain cases,
 perhaps using a PR or forked version of this package, you may need to
 import the source Vue component directly from the package. To do this,
 just append the import with the path to the Vue component: 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ To prevent the route from being preloaded, the return value of the
 callback must explicitly return `false`. Optionally, a `Promise` may
 be returned that can ultimately be resolved to a boolean.
 
-Any errors or rejections encountered during the callback are intentionally
-caught as preloading is meant to be a passive and non-blocking feature.
-These errors will only be logged to the console if the
-[Vue.config.silent](https://vuejs.org/v2/api/#silent) option is disabled.
+> Note: Any errors or rejections encountered during the callback are intentionally
+> caught as preloading is meant to be a passive and non-blocking feature.
+> These errors will only be logged to the console if the
+> [Vue.config.silent](https://vuejs.org/v2/api/#silent) option is disabled.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ When a page is preloaded, a `preload` event is fired:
 
   export {
     methods: {
-      handlePreload(path) {
-        console.info(`Preloading ${path}`);
+      handlePreload(path, route) {
+          console.info(`Preloading ${path}`, route);
       },
     },
     components: {
@@ -93,7 +93,7 @@ associated with just mounting a vue component.
 You can also supply the `preload` meta property with a callback
 function. This callback is passed two parameters:
 
-- `href` - (string) The link href value (stripped of any router base path).
+- `path` - (string) The link href value (stripped of any router base path).
 - `route` - (Route) The matched route object.
 
 To prevent the route from being preloaded, the return value of the
@@ -109,7 +109,7 @@ feature.
   path: '/process-intensive-route',
   // ...
   meta: {
-    preload: (href, route) => startFetchingOtherResources(route),
+    preload: (path, route) => startFetchingOtherResources(route),
   },
 },
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,68 @@ When a page is preloaded, a `preload` event is fired:
 </script>
 ```
 
+## Source vs. Dist
+
+By default, the `main` entry points to the compiled and minified version
+of the Vue template. This is typically fine. However, in certain cases,
+perhaps using a PR or forked version of this package, you may need to
+import the source Vue component directly from the package. To do this,
+just append the import with the path to the Vue component: 
+
+```js
+import Futurelink from 'vue-futurelink/src/Futurelink';
+```
+
+> Note: doing this requires that your build system is using
+ [vue-loader](https://github.com/vuejs/vue-loader) so it can compile the
+ Vue [SFC](https://github.com/vuejs/vue-loader/blob/master/docs/spec.md). 
+
+## route.meta.preload
+
+In some cases, actionable routes shouldn't be preloaded (i.e. `/logout`).
+
+You can explicitly set the `preload` meta property of a route to
+`false` to prevent it from being preloaded:
+
+```js
+{
+  path: '/logout',
+  // ...
+  meta: {
+    preload: false,
+  },
+},
+```
+
+In other cases, routes that can be resource intensive may need more
+complex handling to preload additional resources not typically
+associated with just mounting a vue component.
+
+You can also supply the `preload` meta property with a callback
+function. This callback is passed two parameters:
+
+- `href` - (string) The link href value (stripped of any router base path).
+- `route` - (Route) The matched route object.
+
+To prevent the route from being preloaded, the return value of the
+callback must explicitly return `false`. Optionally, a `Promise` may
+be returned that can ultimately be resolved to a boolean.
+
+Any errors or rejections encountered during the callback will be
+intentionally silenced as preloading is meant to be a passive
+feature.
+
+```js
+{
+  path: '/process-intensive-route',
+  // ...
+  meta: {
+    preload: (href, route) => startFetchingOtherResources(route),
+  },
+},
+```
+
+
 ## License
 
 Released under the MIT license.

--- a/src/Futurelink.vue
+++ b/src/Futurelink.vue
@@ -43,11 +43,18 @@
 
         loaded.push(href);
 
-        this.$emit('preload', href);
-
         const resolved = this.$router.resolve(href);
         const matched = resolved.resolved.matched;
-        this.preloadComponent = matched[matched.length - 1].components.default;
+        const route = matched[matched.length - 1];
+        // Only preload if a route was found.
+        if (route) {
+          // If the route has a preload meta property, check whether the route should be preloaded.
+          if ((typeof route.meta.preload === 'function' && route.meta.preload(href, route) === false) || route.meta.preload !== false) {
+            return
+          }
+          this.$emit('preload', href, route);
+          this.preloadComponent = route.components.default;
+        }
       };
 
       this.instance = futurelink(this.options);

--- a/src/Futurelink.vue
+++ b/src/Futurelink.vue
@@ -28,7 +28,7 @@
         },
       }
     },
-    destroyed() {
+    beforeDestroy() {
       if (this.instance) {
         this.instance.teardown();
       }

--- a/src/Futurelink.vue
+++ b/src/Futurelink.vue
@@ -49,7 +49,7 @@
         // Only preload if a route was found.
         if (route) {
           // If the route has a preload meta property, check whether the route should be preloaded.
-          if ((typeof route.meta.preload === 'function' && route.meta.preload(href, route) === false) || route.meta.preload !== false) {
+          if ((typeof route.meta.preload === 'function' && route.meta.preload(href, route) === false) || route.meta.preload === false) {
             return;
           }
           this.$emit('preload', href, route);

--- a/src/Futurelink.vue
+++ b/src/Futurelink.vue
@@ -50,7 +50,7 @@
         if (route) {
           // If the route has a preload meta property, check whether the route should be preloaded.
           if ((typeof route.meta.preload === 'function' && route.meta.preload(href, route) === false) || route.meta.preload !== false) {
-            return
+            return;
           }
           this.$emit('preload', href, route);
           this.preloadComponent = route.components.default;

--- a/src/Futurelink.vue
+++ b/src/Futurelink.vue
@@ -16,6 +16,11 @@
         throw new Error('vue-futurelink requires vue-router to function.');
       }
     },
+    beforeDestroy() {
+      if (this.instance) {
+        this.instance.teardown();
+      }
+    },
     data() {
       return {
         basePath: this.$router.options.base ? this.$router.options.base : '/',
@@ -26,11 +31,6 @@
           future: this.preloadLink,
           links: [],
         },
-      }
-    },
-    beforeDestroy() {
-      if (this.instance) {
-        this.instance.teardown();
       }
     },
     methods: {


### PR DESCRIPTION
In some cases, actionable routes shouldn't be preloaded (i.e. /logout).

This allows a route to set a meta property to explicitly disallow it from being preloaded:

```js
{
  path: '/logout',
  // ...
  meta: {
    preload: false,
  },
},
```

Optionally, it can also be set to a function for more dynamic handling:

```js
{
  path: '/process-intensive-route',
  // ...
  meta: {
    preload: (href, route) => startFetchingOtherResources(route),
  },
},
```
